### PR TITLE
Various bug fixes and improvements.

### DIFF
--- a/NSArray+LinqExtensions.h
+++ b/NSArray+LinqExtensions.h
@@ -8,30 +8,30 @@
 
 #import <Foundation/Foundation.h>
 
-typedef BOOL (^Condition)(id item);
+typedef BOOL (^MSLINQCondition)(id item);
 
-typedef id (^Selector)(id item);
+typedef id (^MSLINQSelector)(id item);
 
-typedef id (^Accumulator)(id item, id aggregate);
+typedef id (^MSLINQAccumulator)(id item, id aggregate);
 
 /**
  Various NSArray extensions that provide a Linq-style query API
  */
-@interface NSArray (LinqExtensions)
+@interface NSArray (MSLINQ)
 
 /** Filters a sequence of values based on a predicate.
  
  @param predicate The function to test each source element for a condition.
  @return An array that contains elements from the input sequence that satisfy the condition.
  */
-- (NSArray*) where:(Condition)predicate;
+- (NSArray*) where:(MSLINQCondition)predicate;
 
 /** Projects each element of a sequence into a new form.
  
  @param selector A transform function to apply to each element.
  @return An array whose elements are the result of invoking the transform function on each element of source.
  */
-- (NSArray*) select:(Selector)transform;
+- (NSArray*) select:(MSLINQSelector)transform;
 
 /** Sorts the elements of a sequence in ascending order.
  
@@ -44,7 +44,7 @@ typedef id (^Accumulator)(id item, id aggregate);
  @param keySelector A selector that provides the 'key' which the array should by sorted by. 
  @return An array whose elements are sorted in ascending order.
  */
-- (NSArray*) sort:(Selector)keySelector;
+- (NSArray*) sort:(MSLINQSelector)keySelector;
 
 /** Filters the elements of an an array based on a specified type.
  
@@ -58,7 +58,7 @@ typedef id (^Accumulator)(id item, id aggregate);
  @param transform A transform function to apply to each element, this should return an NSArray.
  @return An array whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
  */
-- (NSArray*) selectMany:(Selector)transform;
+- (NSArray*) selectMany:(MSLINQSelector)transform;
 
 /** Returns distinct elements from a sequence.
  
@@ -71,14 +71,14 @@ typedef id (^Accumulator)(id item, id aggregate);
  @param keySelector Specifies the value to use for equality for each item.
  @return An array of distinct elements.
  */
-- (NSArray*) distinct:(Selector)keySelector;
+- (NSArray*) distinct:(MSLINQSelector)keySelector;
 
 /** Applies an accumulator function over a sequence. The item in the array is used as the initial aggregate value.
  
  @param accumulator An accumulator function to be invoked on each element.
  @return The final accumulator value.
  */
-- (id) aggregate:(Accumulator)accumulator;
+- (id) aggregate:(MSLINQAccumulator)accumulator;
 
 /** Returns the first item from the source array, or nil if the array is empty.
  
@@ -111,21 +111,21 @@ typedef id (^Accumulator)(id item, id aggregate);
  @param condition The condition to test elements against.
  @return Whether all the elements of the array satisfies a condition.
  */
-- (BOOL) all:(Condition)condition;
+- (BOOL) all:(MSLINQCondition)condition;
 
 /** Determines whether any of the elements of the array satisfies a condition.
  
  @param condition The condition to test elements against.
  @return Whether any of the elements of the array satisfies a condition.
  */
-- (BOOL) any:(Condition)condition;
+- (BOOL) any:(MSLINQCondition)condition;
 
 /** Groups the elements of the array by keys provided by the given key selector. The returned dictionary will contain the keys that are the result of applying the key selector function to each item of the array, and the value for each key is an array of all the items that return the same key value.
  
  @param groupKeySelector Determines the group key for each item in the array
  @return A dictionary that groups the items via the given key selector.
  */
-- (NSDictionary*) groupBy:(Selector)groupKeySelector;
+- (NSDictionary*) groupBy:(MSLINQSelector)groupKeySelector;
 
 /** Transforms the source array into a dictionary by applying the given keySelector and valueSelector to each item in the array.
  
@@ -133,21 +133,21 @@ typedef id (^Accumulator)(id item, id aggregate);
  @param valueSelector A selector function that is applied to each item to determine the value it will have within the returned dictionary.
  @return A dictionary that is the result of applying the supplied selector functions to each item of the array.
  */
-- (NSDictionary*) toDictionaryWithKeySelector:(Selector)keySelector valueSelector:(Selector)valueSelector;
+- (NSDictionary*) toDictionaryWithKeySelector:(MSLINQSelector)keySelector valueSelector:(MSLINQSelector)valueSelector;
 
 /** Transforms the source array into a dictionary by applying the given keySelectorto each item in the array.
  
  @param keySelector A selector function that is applied to each item to determine the key it will have within the returned dictionary.
  @return A dictionary that is the result of applying the supplied selector functions to each item of the array.
  */
-- (NSDictionary*) toDictionaryWithKeySelector:(Selector)keySelector;
+- (NSDictionary*) toDictionaryWithKeySelector:(MSLINQSelector)keySelector;
 
 /** Counts the number of elements in the array that satisfy the given condition.
  
  @param condition The condition to test elements against.
  @return The number of elements that satisfy the condition.
  */
-- (NSUInteger) count:(Condition)condition;
+- (NSUInteger) count:(MSLINQCondition)condition;
 
 /** Concatonates the given array to the end of this array.
  

--- a/NSDictionary+LinqExtensions.h
+++ b/NSDictionary+LinqExtensions.h
@@ -8,56 +8,56 @@
 
 #import <Foundation/Foundation.h>
 
-typedef id (^KeyValueSelector)(id key, id value);
+typedef id (^MSLINQKeyValueSelector)(id key, id value);
 
-typedef BOOL (^KeyValueCondition)(id key, id value);
+typedef BOOL (^MSLINQKeyValueCondition)(id key, id value);
 
 /**
  Various NSDictionary extensions that provide a Linq-style query API
  */
-@interface NSDictionary (LinqExtensions)
+@interface NSDictionary (MSLINQ)
 
 /** Filters a dictionary based on a predicate.
  
  @param predicate The function to test each source key-value pair for a condition.
  @return A dictionary that contains key-value pairs from the input dictionary that satisfy the condition.
  */
-- (NSDictionary*) where:(KeyValueCondition)predicate;
+- (NSDictionary*) where:(MSLINQKeyValueCondition)predicate;
 
 /** Projects each element of the dictionary into a new form.
  
  @param selector A transform function to apply to each element.
  @return A dicionary whose elements are the result of invoking the transform function on each key-value pair of source.
  */
-- (NSDictionary*) select:(KeyValueSelector)selector;
+- (NSDictionary*) select:(MSLINQKeyValueSelector)selector;
 
 /** Projects each element of the dictionary to a new form, which is used to populate the returned array.
  
  @param selector A transform function to apply to each element.
  @return An array whose elements are the result of invoking the transform function on each key-value pair of source.
  */
-- (NSArray*) toArray:(KeyValueSelector)selector;
+- (NSArray*) toArray:(MSLINQKeyValueSelector)selector;
 
 /** Determines whether all of the key-value pairs of the dictionary satisfies a condition.
  
  @param condition The condition to test key-value pairs against.
  @return Whether any of the element of the dictionary satisfies a condition.
  */
-- (BOOL) all:(KeyValueCondition)condition;
+- (BOOL) all:(MSLINQKeyValueCondition)condition;
 
 /** Determines whether any of the key-value pairs of the dictionary satisfies a condition.
  
  @param condition The condition to test key-value pairs against.
  @return Whether any of the element of the dictionary satisfies a condition.
  */
-- (BOOL) any:(KeyValueCondition)condition;
+- (BOOL) any:(MSLINQKeyValueCondition)condition;
 
 /** Counts the number of key-value pairs that satisfy the given condition.
  
  @param condition The condition to test key-value pairs against.
  @return The number of elements that satisfy the condition.
  */
-- (NSUInteger) count:(KeyValueCondition)condition;
+- (NSUInteger) count:(MSLINQKeyValueCondition)condition;
 
 /** Merges the contents of this dictionary with the given dictionary. For any duplicates, the value from
  the source dictionary will be used.

--- a/NSDictionary+LinqExtensions.m
+++ b/NSDictionary+LinqExtensions.m
@@ -8,9 +8,9 @@
 
 #import "NSDictionary+LinqExtensions.h"
 
-@implementation NSDictionary (LinqExtensions)
+@implementation NSDictionary (MSLINQ)
 
-- (NSDictionary *)where:(KeyValueCondition)predicate
+- (NSDictionary *)where:(MSLINQKeyValueCondition)predicate
 {
     NSMutableDictionary* result = [[NSMutableDictionary alloc] init];
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -21,25 +21,32 @@
     return result;
 }
 
-- (NSDictionary *)select:(KeyValueSelector)selector
+- (NSDictionary *)select:(MSLINQKeyValueSelector)selector
 {
     NSMutableDictionary* result = [[NSMutableDictionary alloc] init];
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        [result setObject:selector(key, obj) forKey:key];
+        id object = selector(key, obj);
+        if (!object)
+            object = [NSNull null];
+        
+        [result setObject:object forKey:key];
     }];
     return result;
 }
 
-- (NSArray *)toArray:(KeyValueSelector)selector
+- (NSArray *)toArray:(MSLINQKeyValueSelector)selector
 {
     NSMutableArray* result = [[NSMutableArray alloc] init];
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        [result addObject:selector(key, obj)];
+        id object = selector(key, obj);
+        if (!object)
+            object = [NSNull null];
+        [result addObject:object];
     }];
     return result;
 }
 
-- (BOOL)all:(KeyValueCondition)condition
+- (BOOL)all:(MSLINQKeyValueCondition)condition
 {
     __block BOOL all = TRUE;
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -51,7 +58,7 @@
     return all;
 }
 
-- (BOOL)any:(KeyValueCondition)condition
+- (BOOL)any:(MSLINQKeyValueCondition)condition
 {
     __block BOOL any = FALSE;
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -63,7 +70,7 @@
     return any;
 }
 
-- (NSUInteger)count:(KeyValueCondition)condition
+- (NSUInteger)count:(MSLINQKeyValueCondition)condition
 {
     return [self where:condition].count;
 }


### PR DESCRIPTION
When I am integrating your code into my library, I am greeted with two issues:
1. I cannot return `nil` from selectors or the code will crash,
2. Types do not have a prefix - they may easily collide (I believe the name `Selector` collides with something in Objective-C runtime.)

I went ahead and fixed them in my library (https://github.com/xcvista/CGIKit) and now I am pushing all changes upstream. (I did not use a submodule so that the build on Linux can be smoother. This library is working fine under Linux with GNUstep.) The `MS` class prefix came out of blue (from the name of my workgroup, _Muski_?) and you can safely `sed` them away if you like to.
