### PR TITLE
Added the 'sum' operation to the NSArray method extensions and unit test...

### DIFF
--- a/LinqToObjectiveCTest/LinqToObjectiveCTestTests/NSArrayLinqExtensionsTest.m
+++ b/LinqToObjectiveCTest/LinqToObjectiveCTestTests/NSArrayLinqExtensionsTest.m
@@ -478,4 +478,12 @@
     STAssertEqualObjects(result[1], @25, nil);
 }
 
+- (void) testSum
+{
+    NSArray* input = @[@25, @35];
+    
+    NSNumber* sum = [input linq_sum];
+    STAssertEqualObjects(sum, @60, nil);
+}
+
 @end

--- a/NSArray+LinqExtensions.h
+++ b/NSArray+LinqExtensions.h
@@ -194,4 +194,10 @@ typedef id (^LINQAccumulator)(id item, id aggregate);
  */
 - (NSArray*) linq_reverse;
 
+/** Sums the elements in the array.
+ 
+ @return The sum of elements within this array.
+ */
+- (NSNumber*)linq_sum;
+
 @end

--- a/NSArray+LinqExtensions.m
+++ b/NSArray+LinqExtensions.m
@@ -237,5 +237,9 @@
     return result;
 }
 
+- (NSNumber *)linq_sum
+{
+    return [self valueForKeyPath: @"@sum.self"];
+}
 
 @end


### PR DESCRIPTION
I have found myself wanting to use a 'sum' operation on arrays for some time, and this is included in the C# Linq extensions. I thought I would add it here too.
