### PR TITLE
Fixed crash when aggregator returns other type

### DIFF
--- a/NSArray+LinqExtensions.m
+++ b/NSArray+LinqExtensions.m
@@ -138,12 +138,9 @@
 - (id)linq_aggregate:(LINQAccumulator)accumulator
 {
     id aggregate = nil;
-    for (id item in self) {
-        if (aggregate == nil) {
-            aggregate = item;
-        } else {
-            aggregate = accumulator(item, aggregate);
-        }
+    for (id item in self)
+    {
+        aggregate = accumulator(item, aggregate);
     }
     return aggregate;
 }


### PR DESCRIPTION
Issue description :
https://github.com/ColinEberhardt/LinqToObjectiveC/issues/12