### PR TITLE
Add TVos and OSX targets. Add a number of new linq extensions.

### DIFF
--- a/LinqToObjectiveC/LinqToObjectiveC-OSX/Info.plist
+++ b/LinqToObjectiveC/LinqToObjectiveC-OSX/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 scottlogic. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/LinqToObjectiveC/LinqToObjectiveC-OSX/LinqToObjectiveC-OSX.h
+++ b/LinqToObjectiveC/LinqToObjectiveC-OSX/LinqToObjectiveC-OSX.h
@@ -1,0 +1,19 @@
+//
+//  LinqToObjectiveC-OSX.h
+//  LinqToObjectiveC-OSX
+//
+//  Created by Tom Davidson on 1/13/16.
+//  Copyright © 2016 scottlogic. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for LinqToObjectiveC-OSX.
+FOUNDATION_EXPORT double LinqToObjectiveC_OSXVersionNumber;
+
+//! Project version string for LinqToObjectiveC-OSX.
+FOUNDATION_EXPORT const unsigned char LinqToObjectiveC_OSXVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <LinqToObjectiveC_OSX/PublicHeader.h>
+
+

--- a/LinqToObjectiveC/LinqToObjectiveC-TVos/Info.plist
+++ b/LinqToObjectiveC/LinqToObjectiveC-TVos/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/LinqToObjectiveC/LinqToObjectiveC-TVos/LinqToObjectiveC-TVos.h
+++ b/LinqToObjectiveC/LinqToObjectiveC-TVos/LinqToObjectiveC-TVos.h
@@ -1,0 +1,19 @@
+//
+//  LinqToObjectiveC-TVos.h
+//  LinqToObjectiveC-TVos
+//
+//  Created by Tom Davidson on 1/13/16.
+//  Copyright © 2016 scottlogic. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for LinqToObjectiveC-TVos.
+FOUNDATION_EXPORT double LinqToObjectiveC_TVosVersionNumber;
+
+//! Project version string for LinqToObjectiveC-TVos.
+FOUNDATION_EXPORT const unsigned char LinqToObjectiveC_TVosVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <LinqToObjectiveC_TVos/PublicHeader.h>
+
+

--- a/LinqToObjectiveC/LinqToObjectiveC.xcodeproj/project.pbxproj
+++ b/LinqToObjectiveC/LinqToObjectiveC.xcodeproj/project.pbxproj
@@ -7,6 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3EDC72291C4679F300A5372E /* LinqToObjectiveC-TVos.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDC72281C4679F300A5372E /* LinqToObjectiveC-TVos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC723D1C467AC100A5372E /* LinqToObjectiveC.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E8F439C1A8B931C000F5D01 /* LinqToObjectiveC.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC723E1C467AC800A5372E /* NSArray+LinqExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E8F439D1A8B931C000F5D01 /* NSArray+LinqExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC723F1C467ACE00A5372E /* NSArray+LinqExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F439E1A8B931C000F5D01 /* NSArray+LinqExtensions.m */; };
+		3EDC72401C467AD300A5372E /* NSDictionary+LinqExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E8F439F1A8B931C000F5D01 /* NSDictionary+LinqExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC72411C467AD900A5372E /* NSDictionary+LinqExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F43A01A8B931C000F5D01 /* NSDictionary+LinqExtensions.m */; };
+		3EDC724A1C467BC900A5372E /* LinqToObjectiveC-OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDC72491C467BC900A5372E /* LinqToObjectiveC-OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC725E1C467C1700A5372E /* LinqToObjectiveC.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E8F439C1A8B931C000F5D01 /* LinqToObjectiveC.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC725F1C467C1C00A5372E /* NSArray+LinqExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E8F439D1A8B931C000F5D01 /* NSArray+LinqExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC72601C467C2500A5372E /* NSArray+LinqExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F439E1A8B931C000F5D01 /* NSArray+LinqExtensions.m */; };
+		3EDC72611C467C2A00A5372E /* NSDictionary+LinqExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E8F439F1A8B931C000F5D01 /* NSDictionary+LinqExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EDC72621C467C3000A5372E /* NSDictionary+LinqExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F43A01A8B931C000F5D01 /* NSDictionary+LinqExtensions.m */; };
 		7E8F43A11A8B931C000F5D01 /* NSArray+LinqExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F439E1A8B931C000F5D01 /* NSArray+LinqExtensions.m */; };
 		7E8F43A21A8B931C000F5D01 /* NSDictionary+LinqExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F43A01A8B931C000F5D01 /* NSDictionary+LinqExtensions.m */; };
 		7EEE35AD1AB4711000668C3E /* LinqToObjectiveC-iOS-dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EEE35AC1AB4711000668C3E /* LinqToObjectiveC-iOS-dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -36,6 +48,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3EDC72261C4679F300A5372E /* LinqToObjectiveC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LinqToObjectiveC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3EDC72281C4679F300A5372E /* LinqToObjectiveC-TVos.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LinqToObjectiveC-TVos.h"; sourceTree = "<group>"; };
+		3EDC722A1C4679F300A5372E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3EDC72471C467BC900A5372E /* LinqToObjectiveC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LinqToObjectiveC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3EDC72491C467BC900A5372E /* LinqToObjectiveC-OSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LinqToObjectiveC-OSX.h"; sourceTree = "<group>"; };
+		3EDC724B1C467BC900A5372E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7E8F43811A8B92D5000F5D01 /* libLinqToObjectiveC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLinqToObjectiveC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8F43921A8B92D5000F5D01 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7E8F439C1A8B931C000F5D01 /* LinqToObjectiveC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LinqToObjectiveC.h; path = ../LinqToObjectiveC.h; sourceTree = "<group>"; };
@@ -52,6 +70,20 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3EDC72221C4679F300A5372E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EDC72431C467BC900A5372E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7E8F437E1A8B92D5000F5D01 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -76,6 +108,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3EDC72271C4679F300A5372E /* LinqToObjectiveC-TVos */ = {
+			isa = PBXGroup;
+			children = (
+				3EDC72281C4679F300A5372E /* LinqToObjectiveC-TVos.h */,
+				3EDC722A1C4679F300A5372E /* Info.plist */,
+			);
+			path = "LinqToObjectiveC-TVos";
+			sourceTree = "<group>";
+		};
+		3EDC72481C467BC900A5372E /* LinqToObjectiveC-OSX */ = {
+			isa = PBXGroup;
+			children = (
+				3EDC72491C467BC900A5372E /* LinqToObjectiveC-OSX.h */,
+				3EDC724B1C467BC900A5372E /* Info.plist */,
+			);
+			path = "LinqToObjectiveC-OSX";
+			sourceTree = "<group>";
+		};
 		7E8F43781A8B92D5000F5D01 = {
 			isa = PBXGroup;
 			children = (
@@ -83,6 +133,8 @@
 				7E8F43901A8B92D5000F5D01 /* LinqToObjectiveCTests */,
 				7EEE35A91AB4711000668C3E /* LinqToObjectiveC-iOS-dynamic */,
 				7EEE35CC1AB4718500668C3E /* LinqToObjectiveC-iOS-static */,
+				3EDC72271C4679F300A5372E /* LinqToObjectiveC-TVos */,
+				3EDC72481C467BC900A5372E /* LinqToObjectiveC-OSX */,
 				7E8F43821A8B92D5000F5D01 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -93,6 +145,8 @@
 				7E8F43811A8B92D5000F5D01 /* libLinqToObjectiveC.a */,
 				7EEE35A81AB4711000668C3E /* LinqToObjectiveC.framework */,
 				7EEE35CB1AB4718500668C3E /* LinqToObjectiveC.framework */,
+				3EDC72261C4679F300A5372E /* LinqToObjectiveC.framework */,
+				3EDC72471C467BC900A5372E /* LinqToObjectiveC.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -162,6 +216,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		3EDC72231C4679F300A5372E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EDC72291C4679F300A5372E /* LinqToObjectiveC-TVos.h in Headers */,
+				3EDC72401C467AD300A5372E /* NSDictionary+LinqExtensions.h in Headers */,
+				3EDC723E1C467AC800A5372E /* NSArray+LinqExtensions.h in Headers */,
+				3EDC723D1C467AC100A5372E /* LinqToObjectiveC.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EDC72441C467BC900A5372E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EDC724A1C467BC900A5372E /* LinqToObjectiveC-OSX.h in Headers */,
+				3EDC72611C467C2A00A5372E /* NSDictionary+LinqExtensions.h in Headers */,
+				3EDC725F1C467C1C00A5372E /* NSArray+LinqExtensions.h in Headers */,
+				3EDC725E1C467C1700A5372E /* LinqToObjectiveC.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7EEE35A51AB4711000668C3E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -187,6 +263,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		3EDC72251C4679F300A5372E /* LinqToObjectiveC-TVos */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EDC723B1C4679F300A5372E /* Build configuration list for PBXNativeTarget "LinqToObjectiveC-TVos" */;
+			buildPhases = (
+				3EDC72211C4679F300A5372E /* Sources */,
+				3EDC72221C4679F300A5372E /* Frameworks */,
+				3EDC72231C4679F300A5372E /* Headers */,
+				3EDC72241C4679F300A5372E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "LinqToObjectiveC-TVos";
+			productName = "LinqToObjectiveC-TVos";
+			productReference = 3EDC72261C4679F300A5372E /* LinqToObjectiveC.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		3EDC72461C467BC900A5372E /* LinqToObjectiveC-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EDC72581C467BC900A5372E /* Build configuration list for PBXNativeTarget "LinqToObjectiveC-OSX" */;
+			buildPhases = (
+				3EDC72421C467BC900A5372E /* Sources */,
+				3EDC72431C467BC900A5372E /* Frameworks */,
+				3EDC72441C467BC900A5372E /* Headers */,
+				3EDC72451C467BC900A5372E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "LinqToObjectiveC-OSX";
+			productName = "LinqToObjectiveC-OSX";
+			productReference = 3EDC72471C467BC900A5372E /* LinqToObjectiveC.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		7E8F43801A8B92D5000F5D01 /* LinqToObjectiveC */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7E8F43951A8B92D5000F5D01 /* Build configuration list for PBXNativeTarget "LinqToObjectiveC" */;
@@ -249,6 +361,12 @@
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = scottlogic;
 				TargetAttributes = {
+					3EDC72251C4679F300A5372E = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					3EDC72461C467BC900A5372E = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					7E8F43801A8B92D5000F5D01 = {
 						CreatedOnToolsVersion = 6.1.1;
 					};
@@ -275,11 +393,27 @@
 				7E8F43801A8B92D5000F5D01 /* LinqToObjectiveC */,
 				7EEE35A71AB4711000668C3E /* LinqToObjectiveC-iOS-dynamic */,
 				7EEE35CA1AB4718500668C3E /* LinqToObjectiveC-iOS-static */,
+				3EDC72251C4679F300A5372E /* LinqToObjectiveC-TVos */,
+				3EDC72461C467BC900A5372E /* LinqToObjectiveC-OSX */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3EDC72241C4679F300A5372E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EDC72451C467BC900A5372E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7EEE35A61AB4711000668C3E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -297,6 +431,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3EDC72211C4679F300A5372E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EDC72411C467AD900A5372E /* NSDictionary+LinqExtensions.m in Sources */,
+				3EDC723F1C467ACE00A5372E /* NSArray+LinqExtensions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EDC72421C467BC900A5372E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EDC72621C467C3000A5372E /* NSDictionary+LinqExtensions.m in Sources */,
+				3EDC72601C467C2500A5372E /* NSArray+LinqExtensions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7E8F437D1A8B92D5000F5D01 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -327,6 +479,110 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		3EDC72371C4679F300A5372E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "LinqToObjectiveC-TVos/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.dodikk.LinqToObjectiveC.LinqToObjectiveC-TVos";
+				PRODUCT_NAME = LinqToObjectiveC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3EDC72381C4679F300A5372E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "LinqToObjectiveC-TVos/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.dodikk.LinqToObjectiveC.LinqToObjectiveC-TVos";
+				PRODUCT_NAME = LinqToObjectiveC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3EDC72591C467BC900A5372E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "LinqToObjectiveC-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.dodikk.LinqToObjectiveC.LinqToObjectiveC-OSX";
+				PRODUCT_NAME = LinqToObjectiveC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3EDC725A1C467BC900A5372E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "LinqToObjectiveC-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.dodikk.LinqToObjectiveC.LinqToObjectiveC-OSX";
+				PRODUCT_NAME = LinqToObjectiveC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		7E8F43931A8B92D5000F5D01 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -512,6 +768,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3EDC723B1C4679F300A5372E /* Build configuration list for PBXNativeTarget "LinqToObjectiveC-TVos" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EDC72371C4679F300A5372E /* Debug */,
+				3EDC72381C4679F300A5372E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		3EDC72581C467BC900A5372E /* Build configuration list for PBXNativeTarget "LinqToObjectiveC-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EDC72591C467BC900A5372E /* Debug */,
+				3EDC725A1C467BC900A5372E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		7E8F437C1A8B92D5000F5D01 /* Build configuration list for PBXProject "LinqToObjectiveC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -537,6 +809,7 @@
 				7EEE35BC1AB4711000668C3E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		7EEE35DE1AB4718500668C3E /* Build configuration list for PBXNativeTarget "LinqToObjectiveC-iOS-static" */ = {
 			isa = XCConfigurationList;
@@ -545,6 +818,7 @@
 				7EEE35E01AB4718500668C3E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/LinqToObjectiveC/LinqToObjectiveC.xcodeproj/project.pbxproj
+++ b/LinqToObjectiveC/LinqToObjectiveC.xcodeproj/project.pbxproj
@@ -775,6 +775,7 @@
 				3EDC72381C4679F300A5372E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		3EDC72581C467BC900A5372E /* Build configuration list for PBXNativeTarget "LinqToObjectiveC-OSX" */ = {
 			isa = XCConfigurationList;
@@ -783,6 +784,7 @@
 				3EDC725A1C467BC900A5372E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		7E8F437C1A8B92D5000F5D01 /* Build configuration list for PBXProject "LinqToObjectiveC" */ = {
 			isa = XCConfigurationList;

--- a/LinqToObjectiveC/LinqToObjectiveC.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LinqToObjectiveC/LinqToObjectiveC.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/NSArray+LinqExtensions.h
+++ b/NSArray+LinqExtensions.h
@@ -209,4 +209,54 @@ the projection fails and returns nil.
  */
 - (NSNumber*)linq_sum;
 
+/**	Determines if an array contains an entry using its 'isEqual' as the test.
+ 
+ @param test The object to check for.
+ @return YES if the array contains the specified object.
+ */
+- (BOOL)linq_contains:(id)id;
+
+/**	Returns the elements of the first array that are NOT in the second.
+ 
+ @param second The array containing the subset of the elements.
+ @return An array of all elements in 'self' that are NOT found in 'second' (using 'isEqual')
+ */
+- (NSArray*)linq_except:(NSArray*)second;
+
+/**	returns an array of all objects found in the first array that ARE found in the second.
+ */
+- (NSArray*)linq_intersect:(NSArray*)second;
+
+/** returns an array of all objects found both in the first and the second arrays.
+ */
+- (NSArray*)linq_union:(NSArray*)second;
+
+/** Determines if two arrays contain the same items (regardless of order).
+ 
+ @param first The first array to test.
+ @param second The second array to test.
+ @return YES if both arrays contain the same elements (regardless of order).
+ */
++ (BOOL)linq_sequenceEqual:(NSArray*)first second:(NSArray*)second;
+
+/** Determines if this array contains the same items (regardless of order).
+ 
+ @param self The first array to test.
+ @param second The second array to test.
+ @return YES if both arrays contain the same elements (regardless of order).
+ */
+- (BOOL)linq_sequenceEqual:(NSArray*)second;
+
+/**
+ *  Returns a range from an array that meets a condition. Scanning stops
+ *  at the first entry that does NOT match.
+ */
+- (NSRange)rangeSatisfying:(LINQCondition)predicate startingIndex:(NSUInteger)index;
+
+/**
+ *  Returns a range from an array that meets a condition. Scanning stops
+ *  at the first entry that does NOT match.
+ */
+- (NSRange)rangeSatisfying:(LINQCondition)predicate withRange:(NSRange)range;
+
 @end

--- a/NSArray+LinqExtensions.m
+++ b/NSArray+LinqExtensions.m
@@ -271,4 +271,101 @@
     return [self valueForKeyPath: @"@sum.self"];
 }
 
+- (BOOL)linq_contains:(id)id
+{
+    return [self containsObject:id];
+}
+
+- (NSArray*)linq_except:(NSArray*)second
+{
+    NSMutableArray* result = [[NSMutableArray alloc] initWithCapacity:self.count];
+    for (id x in self)
+    {
+        if (![second linq_contains:x])
+            [result addObject:x];
+    }
+    
+    return result;
+}
+
+- (NSArray*)linq_intersect:(NSArray*)second
+{
+    NSMutableArray *r = [NSMutableArray new];
+    for (id q in self)
+    {
+        if ([second containsObject:q])
+            [r addObject:q];
+    }
+    
+    //    NSLog(@"left-side: %@", self);
+    //    NSLog(@"right-side: %@", second);
+    //    NSLog(@"intersection: %@", r);
+    return r;
+}
+
+- (NSArray*)linq_union:(NSArray *)second
+{
+    NSMutableArray *r = [[NSMutableArray alloc] initWithArray:self];
+    for (id x in second)
+    {
+        if (![r containsObject:x])
+            [r addObject:x];
+    }
+    
+    return r;
+}
+
+- (BOOL)linq_sequenceEqual:(NSArray*)second
+{
+    return [NSArray linq_sequenceEqual:self second:second];
+}
+
++ (BOOL)linq_sequenceEqual:(NSArray*)first second:(NSArray*)second
+{
+    if (first == second)
+        return YES;
+    
+    if ((nil == first) || (nil == second))
+        return NO;
+    
+    if ([first count] != [second count])
+        return NO;
+    
+    int i = 0;
+    for (id x in first)
+    {
+        id y = [second objectAtIndex:i++];
+        if (![x isEqual:y])
+            return NO;
+    }
+    
+    return YES;
+}
+
+- (NSRange)rangeSatisfying:(LINQCondition)predicate startingIndex:(NSUInteger)startingIndex
+{
+    NSRange range;
+    range.location = startingIndex;
+    range.length = [self count] - startingIndex;
+    return [self rangeSatisfying:predicate withRange:range];
+}
+
+- (NSRange)rangeSatisfying:(LINQCondition)predicate withRange:(NSRange)range
+{
+    NSUInteger pos = range.location;
+    NSUInteger limit = pos + range.length;
+    
+    while (pos < limit)
+    {
+        if (!predicate([self objectAtIndex:pos]))
+        {
+            break;
+        }
+        pos++;
+    }
+    
+    range.length = pos - range.location;
+    return range;
+}
+
 @end


### PR DESCRIPTION
Love this extension- so much I've added targets for supporting TVos and Mac OSX. I've also added a few extensions- some set operations and a few other handy NSArray linq_ categories. See the bottom of NSArray+LinqExtensions.h.